### PR TITLE
Change default instance type from t3.medium to t3.small

### DIFF
--- a/eks-install/variables.tf
+++ b/eks-install/variables.tf
@@ -53,7 +53,7 @@ variable "node_groups" {
   }))
   default = {
     general = {
-      instance_types = ["t3.medium"]
+      instance_types = ["t3.small"]
       capacity_type  = "ON_DEMAND"
       scaling_config = {
         desired_size = 2


### PR DESCRIPTION
AWS Free Tier does not provide t3.medium as free anymore, now only t3.micro and t3.small are available for free